### PR TITLE
Bump rosetta version (v0.2.3).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/ElrondNetwork/elrond-config-mainnet --branch=rc
 WORKDIR /go
 # TODO: use tag after release
 RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=rc/2022-july --single-branch
-RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.2 --depth=1
+RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.3 --depth=1
 
 # Build rosetta
 WORKDIR /go/rosetta/cmd/rosetta


### PR DESCRIPTION
Use rosetta `v0.2.3`.