### PR TITLE
Provide CLI argument --num-historical-blocks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/ElrondNetwork/elrond-config-mainnet --branch=rc
 WORKDIR /go
 # TODO: use tag after release
 RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=v1.3.37 --single-branch
-RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.3 --depth=1
+RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.4 --depth=1
 
 # Build rosetta
 WORKDIR /go/rosetta/cmd/rosetta

--- a/devnet.env
+++ b/devnet.env
@@ -15,5 +15,5 @@ PORT_ROSETTA_OFFLINE=7092
 
 # Ideally, should be correlated with "NumEpochsToKeep" (which is set when building the image).
 # Recommended formula: num epochs to keep * num rounds per epoch * a chosen pessimistic hit rate.
-# For example: 720 * 1200 * 0.75
-NUM_HISTORICAL_BLOCKS=648000
+# For example: 1024 * 1200 * 0.75
+NUM_HISTORICAL_BLOCKS=921600

--- a/docker-compose-devnet.yml
+++ b/docker-compose-devnet.yml
@@ -23,7 +23,7 @@ services:
       - "${PORT_ROSETTA_ONLINE}:8080"
     volumes:
       - ${DATA_FOLDER_ROSETTA_ONLINE}:/data
-    command: start-rosetta --port 8080 --observer-http-url=http://11.0.0.10:8080 --observer-pubkey=${OBSERVER_PUBKEY} --chain-id=D --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=XeGLD
+    command: start-rosetta --port 8080 --observer-http-url=http://11.0.0.10:8080 --observer-pubkey=${OBSERVER_PUBKEY} --chain-id=D --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=XeGLD --num-historical-blocks=${NUM_HISTORICAL_BLOCKS}
     networks:
       elrond-rosetta-devnet:
         ipv4_address: 11.0.0.21
@@ -35,7 +35,7 @@ services:
       - "${PORT_ROSETTA_OFFLINE}:8080"
     volumes:
       - ${DATA_FOLDER_ROSETTA_OFFLINE}:/data
-    command: start-rosetta --port 8080 --offline --observer-http-url=http://nowhere.localhost.local --chain-id=D --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=XeGLD
+    command: start-rosetta --port 8080 --offline --observer-http-url=http://nowhere.localhost.local --chain-id=D --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=XeGLD --num-historical-blocks=${NUM_HISTORICAL_BLOCKS}
     networks:
       elrond-rosetta-devnet:
         ipv4_address: 11.0.0.22

--- a/docker-compose-mainnet.yml
+++ b/docker-compose-mainnet.yml
@@ -23,7 +23,7 @@ services:
       - "${PORT_ROSETTA_ONLINE}:8080"
     volumes:
       - ${DATA_FOLDER_ROSETTA_ONLINE}:/data
-    command: start-rosetta --port 8080 --observer-http-url=http://10.0.0.10:8080 --observer-pubkey=${OBSERVER_PUBKEY} --chain-id=1 --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=EGLD
+    command: start-rosetta --port 8080 --observer-http-url=http://10.0.0.10:8080 --observer-pubkey=${OBSERVER_PUBKEY} --chain-id=1 --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=EGLD --num-historical-blocks=${NUM_HISTORICAL_BLOCKS}
     networks:
       elrond-rosetta-mainnet:
         ipv4_address: 10.0.0.21
@@ -35,7 +35,7 @@ services:
       - "${PORT_ROSETTA_OFFLINE}:8080"
     volumes:
       - ${DATA_FOLDER_ROSETTA_OFFLINE}:/data
-    command: start-rosetta --port 8080 --offline --observer-http-url=http://nowhere.localhost.local --chain-id=1 --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=EGLD
+    command: start-rosetta --port 8080 --offline --observer-http-url=http://nowhere.localhost.local --chain-id=1 --num-shards=3 --observer-actual-shard=${OBSERVER_ACTUAL_SHARD} --observer-projected-shard=${OBSERVER_PROJECTED_SHARD} --genesis-block=${GENESIS_BLOCK} --genesis-timestamp=${GENESIS_TIMESTAMP} --native-currency=EGLD --num-historical-blocks=${NUM_HISTORICAL_BLOCKS}
     networks:
       elrond-rosetta-mainnet:
         ipv4_address: 10.0.0.22


### PR DESCRIPTION
 - In docker-compose configuration, provide the CLI argument `--num-historical-blocks`
 - For devnet, adjust the default environment variable `NUM_HISTORICAL_BLOCKS` (with respect to `NumEpochsToKeep`).
 - Bump rosetta version, due to: https://github.com/ElrondNetwork/rosetta/pull/44