### PR TITLE
Reference new elrond-go (faster snapshots), reference newer rosetta (bugfix).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN git clone https://github.com/ElrondNetwork/elrond-config-devnet --branch=rc-
 RUN git clone https://github.com/ElrondNetwork/elrond-config-mainnet --branch=rc-2022-july --depth=1
 WORKDIR /go
 # TODO: use tag after release
-RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=v1.3.37 --single-branch
-RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.4 --depth=1
+RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=rc/2022-july --single-branch
+RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.5 --depth=1
 
 # Build rosetta
 WORKDIR /go/rosetta/cmd/rosetta

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ docker compose --file ./docker-compose-mainnet.yml --env-file ./mainnet.env --pr
 For devnet:
 
 ```
-docker logs elrond-rosetta-observer-devnet -f
-docker logs elrond-rosetta-online-devnet -f
-docker logs elrond-rosetta-offline-devnet -f
+docker logs elrond-rosetta-observer-devnet --tail 100 --follow
+docker logs elrond-rosetta-online-devnet --tail 100 --follow
+docker logs elrond-rosetta-offline-devnet --tail 100 --follow
 ```
 
 For mainnet:
 
 ```
-docker logs elrond-rosetta-observer-mainnet -f
-docker logs elrond-rosetta-online-mainnet -f
-docker logs elrond-rosetta-offline-mainnet -f
+docker logs elrond-rosetta-observer-mainnet --tail 100 --follow
+docker logs elrond-rosetta-online-mainnet --tail 100 --follow
+docker logs elrond-rosetta-offline-mainnet --tail 100 --follow
 ```
 
 ## Update the Docker setup

--- a/docker-compose-devnet.yml
+++ b/docker-compose-devnet.yml
@@ -11,7 +11,7 @@ services:
       - "${PORT_P2P}:37373"
     volumes:
       - ${DATA_FOLDER_OBSERVER}:/data
-    command: start-observer network=devnet --destination-shard-as-observer=${OBSERVER_ACTUAL_SHARD} --log-save --log-level=*:DEBUG --log-logger-name --rest-api-interface=0.0.0.0:8080 --working-directory=/data --validator-key-pem-file=/data/observerKey.pem
+    command: start-observer network=devnet --destination-shard-as-observer=${OBSERVER_ACTUAL_SHARD} --log-save --log-level=*:DEBUG --log-logger-name --rest-api-interface=0.0.0.0:8080 --working-directory=/data --validator-key-pem-file=/data/observerKey.pem --serialize-snapshots --disable-consensus-watchdog
     networks:
       elrond-rosetta-devnet:
         ipv4_address: 11.0.0.10


### PR DESCRIPTION
 - Reference new elrond-go (faster snapshotting in case of syncing an observer).
 - Reference new rosetta (bugfix related to fee computation in some edge cases).

Now, the devnet observer is started with the flags: `--serialize-snapshots --disable-consensus-watchdog`. The mainnet observer does not need these flags (longer epochs, less snapshotting).

Related PRs:
 - https://github.com/ElrondNetwork/elrond-go/pull/4440
 - https://github.com/ElrondNetwork/rosetta/pull/45
