### PR TITLE
Update references (config, binary).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ FROM golang:1.17.6 as builder
 WORKDIR /repos
 RUN git clone https://github.com/ElrondNetwork/rosetta-docker-scripts.git --branch=v0.2.0 --depth=1
 # TODO: use tag after release
-RUN git clone https://github.com/ElrondNetwork/elrond-config-devnet --branch=rc-2022-july --depth=1
+RUN git clone https://github.com/ElrondNetwork/elrond-config-devnet --branch=D1.3.40.0 --depth=1
 # TODO: use tag after release
 RUN git clone https://github.com/ElrondNetwork/elrond-config-mainnet --branch=rc-2022-july --depth=1
 WORKDIR /go
 # TODO: use tag after release
-RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=rc/2022-july --single-branch
+RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=v1.3.40 --single-branch
 RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.5 --depth=1
 
 # Build rosetta


### PR DESCRIPTION
 - New elrond-go binary: `v1.3.40`
 - New elrond-go config for devnet: `D1.3.40.0`

Upgrade announcement for devnet: https://t.me/ElrondValidatorsAnn/507.