### PR TITLE
Config optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN go build .
 
 # Adjust configuration files
 RUN apt-get update && apt-get -y install python3-pip && pip3 install toml
-RUN python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-devnet/config.toml --num-epochs-to-keep=1024 --api-simultaneous-requests=256 && \
+RUN python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-devnet/config.toml --num-epochs-to-keep=1024 --api-simultaneous-requests=16384 && \
     python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=prefs --file=/repos/elrond-config-devnet/prefs.toml && \
-    python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-mainnet/config.toml --num-epochs-to-keep=128 --api-simultaneous-requests=256 && \
+    python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-mainnet/config.toml --num-epochs-to-keep=128 --api-simultaneous-requests=16384 && \
     python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=prefs --file=/repos/elrond-config-mainnet/prefs.toml
 
 # ===== SECOND STAGE ======

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN go build .
 
 # Adjust configuration files
 RUN apt-get update && apt-get -y install python3-pip && pip3 install toml
-RUN python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-devnet/config.toml --num-epochs-to-keep=1024 --api-simultaneous-requests=512 && \
+RUN python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-devnet/config.toml --num-epochs-to-keep=1024 --api-simultaneous-requests=256 && \
     python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=prefs --file=/repos/elrond-config-devnet/prefs.toml && \
-    python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-mainnet/config.toml --num-epochs-to-keep=128 --api-simultaneous-requests=512 && \
+    python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=main --file=/repos/elrond-config-mainnet/config.toml --num-epochs-to-keep=128 --api-simultaneous-requests=256 && \
     python3 /repos/rosetta-docker-scripts/adjust_config.py --mode=prefs --file=/repos/elrond-config-mainnet/prefs.toml
 
 # ===== SECOND STAGE ======

--- a/devnet.env
+++ b/devnet.env
@@ -19,4 +19,4 @@ PORT_ROSETTA_OFFLINE=7092
 # Recommended formula: num epochs to keep * num rounds per epoch * a chosen pessimistic hit rate.
 # For example: 1024 * 1200 * 0.75
 NUM_HISTORICAL_BLOCKS=800000
-LOG_LEVEL=*:INFO
+LOG_LEVEL=*:DEBUG

--- a/devnet.env
+++ b/devnet.env
@@ -19,3 +19,4 @@ PORT_ROSETTA_OFFLINE=7092
 # Recommended formula: num epochs to keep * num rounds per epoch * a chosen pessimistic hit rate.
 # For example: 1024 * 1200 * 0.75
 NUM_HISTORICAL_BLOCKS=800000
+LOG_LEVEL=*:INFO

--- a/docker-compose-devnet.yml
+++ b/docker-compose-devnet.yml
@@ -11,7 +11,7 @@ services:
       - "${PORT_P2P}:37373"
     volumes:
       - ${DATA_FOLDER_OBSERVER}:/data
-    command: start-observer network=devnet --destination-shard-as-observer=${OBSERVER_ACTUAL_SHARD} --log-save --log-level=*:DEBUG --log-logger-name --rest-api-interface=0.0.0.0:8080 --working-directory=/data --validator-key-pem-file=/data/observerKey.pem --serialize-snapshots --disable-consensus-watchdog
+    command: start-observer network=devnet --destination-shard-as-observer=${OBSERVER_ACTUAL_SHARD} --log-save --log-level=${LOG_LEVEL} --log-logger-name --rest-api-interface=0.0.0.0:8080 --working-directory=/data --validator-key-pem-file=/data/observerKey.pem --serialize-snapshots --disable-consensus-watchdog
     networks:
       elrond-rosetta-devnet:
         ipv4_address: 11.0.0.10

--- a/docker-compose-mainnet.yml
+++ b/docker-compose-mainnet.yml
@@ -11,7 +11,7 @@ services:
       - "${PORT_P2P}:37373"
     volumes:
       - ${DATA_FOLDER_OBSERVER}:/data
-    command: start-observer network=mainnet --destination-shard-as-observer=${OBSERVER_ACTUAL_SHARD} --log-save --log-level=*:DEBUG --log-logger-name --rest-api-interface=0.0.0.0:8080 --working-directory=/data --validator-key-pem-file=/data/observerKey.pem
+    command: start-observer network=mainnet --destination-shard-as-observer=${OBSERVER_ACTUAL_SHARD} --log-save --log-level=${LOG_LEVEL} --log-logger-name --rest-api-interface=0.0.0.0:8080 --working-directory=/data --validator-key-pem-file=/data/observerKey.pem
     networks:
       elrond-rosetta-mainnet:
         ipv4_address: 10.0.0.10

--- a/mainnet.env
+++ b/mainnet.env
@@ -19,3 +19,4 @@ PORT_ROSETTA_OFFLINE=8092
 # Recommended formula: num epochs to keep * num rounds per epoch * a chosen pessimistic hit rate.
 # For example: 128 * 14400 * 0.75
 NUM_HISTORICAL_BLOCKS=800000
+LOG_LEVEL=*:DEBUG


### PR DESCRIPTION
 - Allow one to adjust the log-level.
 - Use `--api-simultaneous-requests=16384` on both _mainnet_ and _devnet_. This modifies `data["Antiflood"]["WebServer"]["SimultaneousRequests"]` of `config.toml`.