### PR TITLE
Reference newest rosetta, newest node.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN git clone https://github.com/ElrondNetwork/elrond-config-devnet --branch=D1.
 RUN git clone https://github.com/ElrondNetwork/elrond-config-mainnet --branch=v1.3.42.0-rosetta1 --depth=1
 
 WORKDIR /go
-RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=v1.3.42-rosetta1 --depth=1
-RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.7 --depth=1
+RUN git clone https://github.com/ElrondNetwork/elrond-go.git --branch=v1.3.43-rosetta1 --depth=1
+RUN git clone https://github.com/ElrondNetwork/rosetta.git --branch=v0.2.8 --depth=1
 
 # Build rosetta
 WORKDIR /go/rosetta/cmd/rosetta


### PR DESCRIPTION
 - Reference rosetta [v0.2.8](https://github.com/ElrondNetwork/rosetta/releases/tag/v0.2.8)
 - Reference elrond-go [v1.3.43-rosetta1](https://github.com/ElrondNetwork/elrond-go/releases/tag/v1.3.43-rosetta1)