### PR TITLE
Barnard (Protocol v1.10): reference latest release tag devnet / mainnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG ROSETTA_MAINNET_TAG=v0.7.1
 ARG ROSETTA_DOCKER_SCRIPTS_TAG=v0.2.7
 
 ARG CONFIG_DEVNET_TAG=D1.10.4.0
-ARG CONFIG_MAINNET_TAG=release-v1.10.3.0 # TODO: wait for actual release v1.10.0
+ARG CONFIG_MAINNET_TAG=v1.10.4.0
 
 # Install Python dependencies, necessary for "adjust_binary.py" and "adjust_observer_src.py"
 RUN apt-get update && apt-get -y install python3-pip && pip3 install toml --break-system-packages


### PR DESCRIPTION
 - Devnet tag: https://github.com/multiversx/mx-chain-devnet-config/releases/tag/D1.10.4.0
 - Devnet announcement(s): 
   - https://t.me/MultiversXValidatorsAnn/724
   - https://t.me/MultiversXValidatorsAnn/729
 - Mainnet tag: 
   - https://github.com/multiversx/mx-chain-mainnet-config/releases/tag/v1.10.4.1 OR
   - https://github.com/multiversx/mx-chain-mainnet-config/releases/tag/v1.10.4.0 (works, as well, for non-ARM)
 - Mainnet announcement(s):
   - https://t.me/MultiversXValidatorsAnn/730
   - https://x.com/MultiversX/status/1945848362458349737
 - Barnard Governance Proposal: https://governance.multiversx.com/proposal/erd1qqqqqqqqqqqqqpgqfn2mu8l0dte34eqh6qtgmpjpxpkhunccrl4sy2sp07/2